### PR TITLE
Update to version 0.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
 }
 
 PACKAGE_NAME = 'crystalball'
-__version__ = '0.3.1'
+__version__ = '0.4.1'
 
 setup(name=PACKAGE_NAME,
       version=__version__,


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test --flake8 -v -s .
  ```

  If the flake8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8`
  to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8
  $ autopep8 -r -i .
  $ flake8 .
  ```
