### PR TITLE
Fix use of deprecated numpy dtypes

### DIFF
--- a/crystalball/budget.py
+++ b/crystalball/budget.py
@@ -5,7 +5,7 @@ import numpy as np
 
 def get_budget(nr_sources, nr_rows, nr_chans, nr_corrs, data_type, cb_args,
                fudge_factor=1.25, row2source_ratio=100):
-    systmem = np.float(psutil.virtual_memory()[0])
+    systmem = float(psutil.virtual_memory()[0])
     if not cb_args.num_workers:
         nrthreads = psutil.cpu_count()
     else:

--- a/tests/test_field_selection.py
+++ b/tests/test_field_selection.py
@@ -10,7 +10,7 @@ def test_select_field():
     datasets = []
 
     for field_name in ["DEEP2"]:
-        name = np.asarray([field_name], dtype=np.object)
+        name = np.asarray([field_name], dtype=object)
         ds = Dataset({"NAME": (("row",), da.from_array(name, chunks=1))})
         datasets.append(ds)
 
@@ -20,7 +20,7 @@ def test_select_field():
     datasets = []
 
     for field_name in ["PKS-1934", "3C286", "DEEP2"]:
-        name = np.asarray([field_name], dtype=np.object)
+        name = np.asarray([field_name], dtype=object)
         ds = Dataset({"NAME": (("row",), da.from_array(name, chunks=1))})
         datasets.append(ds)
 


### PR DESCRIPTION
- [ ] Tests added / passed

  ```bash
  $ py.test --flake8 -v -s .
  ```

  If the flake8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8`
  to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8
  $ autopep8 -r -i .
  $ flake8 .
  ```

Fixes https://github.com/caracal-pipeline/crystalball/issues/61