### PR TITLE
Separate CLI and and main flow

### DIFF
--- a/crystalball/ms.py
+++ b/crystalball/ms.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import logging
 
-import pyrap.tables as pt
+import casacore.tables as pt
 
 log = logging.getLogger(__name__)
 
 
-def ms_preprocess(args):
+def ms_preprocess(
+        ms_name: str,
+        output_column: str = "CORRECTED_DATA",
+):
     """
     Adds output column if missing.
 
@@ -18,18 +22,18 @@ def ms_preprocess(args):
     """
 
     # check output column
-    with pt.table(args.ms, readonly=False) as ms:
+    with pt.table(ms_name, readonly=False) as ms:
         # Return if nothing todo
-        if args.output_column in ms.colnames():
+        if output_column in ms.colnames():
             return ms.nrows(), ms.coldatatype('DATA')
 
-        log.info('inserting new column %s', args.output_column)
+        log.info('inserting new column %s', output_column)
         desc = ms.getcoldesc("DATA")
-        desc['name'] = args.output_column
+        desc['name'] = output_column
         # python version hates spaces, who knows why
         desc['comment'] = desc['comment'].replace(" ", "_")
         dminfo = ms.getdminfo("DATA")
-        dminfo["NAME"] = "%s-%s" % (dminfo["NAME"], args.output_column)
+        dminfo["NAME"] = "%s-%s" % (dminfo["NAME"], output_column)
         ms.addcols(desc, dminfo)
 
         return ms.nrows(), ms.coldatatype('DATA')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.rst"
 packages = [{include = "crystalball"}]
 
 [tool.poetry.scripts]
-crystalball = "crystalball.crystalball:predict"
+crystalball = "crystalball.crystalball:predict_cli"
 
 [tool.poetry.dependencies]
 python = "^3.10,<3.13"

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -7,4 +7,7 @@ import pytest
 
 def test_end_to_end(tart_ms_tarfile, sky_model):
   with patch.object(sys, "argv", ["crystalball", "--sky-model", sky_model, tart_ms_tarfile]):
-    predict()
+    predict(
+      ms=tart_ms_tarfile,
+      sky_model=sky_model,
+    )


### PR DESCRIPTION
- [x] Tests added / passed

As described in #69. 

- Changes `_predict` to `predict` with usual Python arguments
- Changes `predict` to `predict_cli` where argparsing happens
- Changes downstream functions to take full set of args/kwargs rather than `args` object
- Removes optional on `dask`/`dask-ms` - looks like nothing could happen without them anyway?

`predict_cli` may need to be patched to match Stimela CLI with `click` and `omegaconf`.

Closes #69 