### PR TITLE
Don't use the dask distributed Client if the scheduler is set to threads

### DIFF
--- a/crystalball/crystalball.py
+++ b/crystalball/crystalball.py
@@ -157,15 +157,16 @@ def construct_client(
     address: str | None = None,
     workers: int = 1,
 ) -> Client:
-    
+
     if scheduler not in ["threads", "distributed"]:
         raise ValueError(f"Unknown scheduler type: {scheduler}")
-    
+
     # Following Quartical's constuction of a dask client
     if scheduler == "threads":
         log.info("Initializing dask client using threads scheduler.")
-        return exitstack.enter_context(Client(n_workers=num_workers))
-    
+        exitstack.enter_context(dask.config.set(num_workers=num_workers))
+        return None
+
     address = address or os.environ.get("DASK_SCHEDULER_ADDRESS")
     if address:
         log.info(


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test --flake8 -v -s .
  ```

  If the flake8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8`
  to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8
  $ autopep8 -r -i .
  $ flake8 .
  ```
